### PR TITLE
Update get_last_login_time_all_users.sql

### DIFF
--- a/get_last_login_time_all_users.sql
+++ b/get_last_login_time_all_users.sql
@@ -9,7 +9,7 @@ INNER JOIN
 FROM 
    Audits 
 WHERE 
-   Audits.action = '/api/v4/users/login' AND Audits.extrainfo = 'success' 
+   Audits.action = '/api/v4/users/login' AND Audits.extrainfo LIKE 'success%' 
 GROUP BY 
    UserId) lastlogin
 ON 
@@ -27,7 +27,7 @@ INNER JOIN
 FROM 
    Audits 
 WHERE 
-   Audits.action = '/api/v4/users/login' AND Audits.extrainfo = 'success' 
+   Audits.action = '/api/v4/users/login' AND Audits.extrainfo LIKE 'success%' 
 GROUP BY 
    UserId) lastlogin
 ON 


### PR DESCRIPTION
Audits.extrainfo field contains `success session_user=<the_userid>` so an exact match on "success" will fail.